### PR TITLE
fix: the __str__ method for quote had tripple p

### DIFF
--- a/backend/shopping/models.py
+++ b/backend/shopping/models.py
@@ -151,7 +151,7 @@ class Quote(models.Model):
     )
 
     def __str__(self):
-        return f"Quote for List {self.shoppping_list.id}"
+        return f"Quote for List {self.shopping_list.id}"
     
     objects = models.Manager()
     active_quotes = QuoteManager()


### PR DESCRIPTION
Models.py database definition for the Quote db model the __str__ method has a typo